### PR TITLE
Fixes for compatibility with python 3 unicode/bytes types

### DIFF
--- a/escpos/config.py
+++ b/escpos/config.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import logging
 import os
 
-from ConfigParser import SafeConfigParser
+from six.moves.configparser import SafeConfigParser
 from collections import namedtuple
 
 from . import constants
@@ -58,7 +58,7 @@ def configure(filename=None):
     parser = SafeConfigParser()
 
     if os.path.isfile(filename):
-        with open(filename, 'r') as fp:
+        with open(filename, 'rt') as fp:
             parser.readfp(fp)
 
     if not parser.has_section(RETRY_SECTION):
@@ -67,7 +67,7 @@ def configure(filename=None):
         parser.set(RETRY_SECTION, 'delay', str(constants.BACKOFF_DEFAULT_DELAY))
         parser.set(RETRY_SECTION, 'factor', str(constants.BACKOFF_DEFAULT_FACTOR))
 
-        with open(filename, 'wb') as fp:
+        with open(filename, 'wt') as fp:
             parser.write(fp)
 
     retry = RetrySettings(

--- a/escpos/conn/file.py
+++ b/escpos/conn/file.py
@@ -72,4 +72,4 @@ class FileConnection(object):
 
 
     def read(self):
-	   pass
+        pass

--- a/escpos/conn/network.py
+++ b/escpos/conn/network.py
@@ -23,6 +23,7 @@ import select
 import socket
 
 from six.moves import range
+from six import text_type
 
 from .. import config
 from ..exceptions import NonReadableSocketError
@@ -149,6 +150,8 @@ class NetworkConnection(object):
 
     def _raw_write(self, data):
         self._assert_writable()
+        if isinstance(data, text_type):
+            data = data.encode()
         totalsent = 0
         while totalsent < len(data):
             sent = self.socket.send(data[totalsent:])


### PR DESCRIPTION
I'm submitting some fixes I needed to do to be able to use `pyescpos` on a py3 project.

Most of the changes are because py3 is sending unicode data to functions that expected bytes. The changes I did were to use `six` lib so the code can run on both py2 and py3.

The fix on `conn/file.py` is because this file mixed tabs and spaces indentation and py3 refuses to run with mixed spacing.

Module `ConfigParser` was renamed on py3, importing from six now.