### PR TITLE
Base: Implemented code page setting.

### DIFF
--- a/escpos/impl/epson.py
+++ b/escpos/impl/epson.py
@@ -185,7 +185,8 @@ class GenericESCPOS(object):
             for char in bytearray(unicode_text, 'cp1251'):
                 printer.device.write(chr(char))
         """
-        assert code_page >= 0 and code_page <= 255
+        if 0 <= code_page <= 255:
+            raise ValueError('Number between 0 and 255 expected.')
         self.device.write('\x1B\x74' + chr(code_page))
 
 

--- a/escpos/impl/epson.py
+++ b/escpos/impl/epson.py
@@ -178,6 +178,17 @@ class GenericESCPOS(object):
         self.device.write('\x1B\x61\x02')
 
 
+    def set_code_page(self, code_page):
+        """Set code page for character printing. This can be used in combination
+        with bytearray to convert encoding. For example:
+
+            for char in bytearray(unicode_text, 'cp1251'):
+                printer.device.write(chr(char))
+        """
+        assert code_page >= 0 and code_page <= 255
+        self.device.write('\x1B\x74' + chr(code_page))
+
+
     def set_text_size(self, width, height):
         if (0 <= width <= 7) and (0 <= height <= 7):
             size = 16 * width + height

--- a/escpos/impl/epson.py
+++ b/escpos/impl/epson.py
@@ -185,7 +185,7 @@ class GenericESCPOS(object):
             for char in bytearray(unicode_text, 'cp1251'):
                 printer.device.write(chr(char))
         """
-        if 0 <= code_page <= 255:
+        if not 0 <= code_page <= 255:
             raise ValueError('Number between 0 and 255 expected.')
         self.device.write('\x1B\x74' + chr(code_page))
 


### PR DESCRIPTION
Add support for setting code page for the printer using generic protocol command supported by many printers.

Only tested with Cyrillic encoding.