### PR TITLE
Made changes to make library Python3 compatible.

### DIFF
--- a/escpos/config.py
+++ b/escpos/config.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import logging
 import os
 
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 from collections import namedtuple
 
 from . import constants

--- a/escpos/conn/file.py
+++ b/escpos/conn/file.py
@@ -23,53 +23,53 @@ from __future__ import print_function
 
 class FileConnection(object):
 
-    SETTINGS_EXAMPLE = '/dev/usb/lp0'
+	SETTINGS_EXAMPLE = '/dev/usb/lp0'
 
 
-    @classmethod
-    def create(cls, settings, **kwargs):
-        return cls(devfile=settings, **kwargs)
+	@classmethod
+	def create(cls, settings, **kwargs):
+		return cls(devfile=settings, **kwargs)
 
 
-    def __init__(self, devfile="/dev/usb/lp0", auto_flush=True):
-        super(FileConnection, self).__init__()
-        self.devfile = devfile
-        self.auto_flush = auto_flush
-        self.open()
+	def __init__(self, devfile="/dev/usb/lp0", auto_flush=True):
+		super(FileConnection, self).__init__()
+		self.devfile = devfile
+		self.auto_flush = auto_flush
+		self.open()
 
 
-    def open(self):
-        """Open system file."""
-        self.device = open(self.devfile, "wb")
-        if self.device is None:
-            print("Could not open the specified file {0}".format(self.devfile))
+	def open(self):
+		"""Open system file."""
+		self.device = open(self.devfile, "wb")
+		if self.device is None:
+			print("Could not open the specified file {0}".format(self.devfile))
 
 
-    def flush(self):
-        """Flush printing content."""
-        self.device.flush()
+	def flush(self):
+		"""Flush printing content."""
+		self.device.flush()
 
 
-    def write(self, data):
-        """Print any command sent in raw format.
+	def write(self, data):
+		"""Print any command sent in raw format.
 
-        :param bytes data: arbitrary code to be printed.
-        """
-        self.device.write(data)
-        if self.auto_flush:
-            self.flush()
-
-
-    def close(self):
-        """Close system file."""
-        if self.device is not None:
-            self.device.flush()
-            self.device.close()
+		:param bytes data: arbitrary code to be printed.
+		"""
+		self.device.write(data)
+		if self.auto_flush:
+			self.flush()
 
 
-    def catch(self):
-        return True
+	def close(self):
+		"""Close system file."""
+		if self.device is not None:
+			self.device.flush()
+			self.device.close()
 
 
-    def read(self):
+	def catch(self):
+		return True
+
+
+	def read(self):
 	   pass

--- a/escpos/impl/epson.py
+++ b/escpos/impl/epson.py
@@ -185,7 +185,7 @@ class GenericESCPOS(object):
             for char in bytearray(unicode_text, 'cp1251'):
                 printer.device.write(chr(char))
         """
-        if 0 <= code_page <= 255:
+        if not 0 <= code_page <= 255:
             raise ValueError('Number between 0 and 255 expected.')
         self.device.write('\x1B\x74' + chr(code_page))
 


### PR DESCRIPTION
Few changes that make this library Python3 compatible. Feel free to just copy them instead of merging. I had to cobble this up fast because I needed it at the time. In short `ConfigParser` has been renamed to `configparser`, and one file needed switching from mixed tabs to pure tabs.