### PR TITLE
[RMV] Bematech 4200TH hinting functions and unused functions

### DIFF
--- a/escpos/impl/bematech.py
+++ b/escpos/impl/bematech.py
@@ -227,23 +227,6 @@ class MP4200TH(epson.GenericESCPOS):
         self._escpos = _ESCPOS(self)
         self._escbema = _ESCBematech(self)
 
-    def set_expanded(self, flag):
-        self._escbema.set_expanded(flag)
-
-    def set_condensed(self, flag):
-        self._escbema.set_condensed(flag)
-
-    def set_emphasized(self, flag):
-        self._escbema.set_emphasized(flag)
-
-    def cut(self, partial=True):
-        if self.hardware_features.get(feature.CUTTER, False):
-            param = b'\x6D' if partial else b'\x69'
-            self.device.write(b'\x1B' + param)
-
-    def _code128_impl(self, data, **kwargs):
-        return self._escbema.code128(data, **kwargs)
-
     def _qrcode_impl(self, data, **kwargs):
         return self._escbema.qrcode(data, **kwargs)
 


### PR DESCRIPTION
Solves [https://github.com/base4sistemas/pyescpos/issues/31](url)

![image](https://github.com/base4sistemas/pyescpos/assets/12245538/fbbe120f-ab74-4420-b99e-791898c59539)

Test code:
```python
from pyescpos.conn.win32 import Win32Raw as Connection
from pyescpos import barcode
from pyescpos.impl.bematech import MP4200TH

conn = Connection.create('MP-4200 TH') # printer name (on windows 10)
impressora = MP4200TH(conn)
impressora.init()


impressora.text("Hello World! 1\nLine")
impressora.lf()

impressora.set_condensed(1)
impressora.text("Hello World! condensed\nLine")
impressora.set_condensed(0)
impressora.lf()

impressora.set_expanded(1)
impressora.text("Hello World! expanded\nLine")
impressora.set_expanded(0)
impressora.lf()

impressora.code128(
        '0123456789',
        barcode_height=96,
        barcode_width=barcode.BARCODE_DOUBLE_WIDTH,
        barcode_hri=barcode.BARCODE_HRI_BOTTOM
    )
impressora.lf()

impressora.ean13(
        '4007817525074',
        barcode_height=120,
        barcode_width=barcode.BARCODE_NORMAL_WIDTH,
        barcode_hri=barcode.BARCODE_HRI_TOP
    )
impressora.cut()
``` 

Printer used:
![WhatsApp Image 2023-06-22 at 10 34 38 AM](https://github.com/base4sistemas/pyescpos/assets/12245538/0889e4cd-d2dc-4dc9-808a-6aa9d8234cca)
